### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -40,12 +47,30 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
     },
     {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": [
+        "alpine_3_24/composer",
+        "alpine_3_24/php85",
+        "alpine_3_24/php85-curl",
+        "alpine_3_24/php85-dom",
+        "alpine_3_24/php85-fpm",
+        "alpine_3_24/php85-iconv",
+        "alpine_3_24/php85-mbstring",
+        "alpine_3_24/php85-session",
+        "alpine_3_24/php85-zip"
+      ],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
+    },
+    {
       "groupName": "PHP",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchDepNames": ["/alpine.*/php.*/"]
     },


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the hassio-addons organization. Every `alpine_X_YY/*` lookup returns `no-result`, so Alpine pins are no longer updated at all, and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard.

This applies the same fix already landed on [app-ssh#1119](https://github.com/hassio-addons/app-ssh/pull/1119):

- Added a custom `alpine` datasource pointed at the Alpine CDN directory listing for `v3.24/main`, parsed as HTML.
- The Alpine custom manager now resolves through `custom.alpine`, with `extractVersionTemplate` pulling the version out of the `.apk` filename. The leading `\d` in that pattern is what stops a package from matching a longer sibling name.
- Both `repology` packageRules switched over to `custom.alpine` (the general automerge rule and the `PHP` group rule).
- Added a rule listing the pins that live in the Alpine **community** repository. Custom datasources use `registryStrategy: "first"`, so multiple `registryUrls` are not tried, and these would not resolve without it.

The community list was derived mechanically from this repository's own `Dockerfile` against the `v3.24` `main` and `community` APKINDEX files, not copied from app-ssh. Of the 10 pins here, only `nginx` lives in `main`; the other 9 (`composer` and the eight `php85*` packages) are in `community`.

## Verification

Done locally, since a passing CI build proves nothing here: this change does not touch the `Dockerfile`, so buildx serves the `apk` layer from cache and no `apk add` runs.

- `renovate-config-validator` passes: "Config validated successfully".
- Local dry run (`RENOVATE_PLATFORM=local`, `RENOVATE_DRY_RUN=lookup`) exits 0.
- `grep -c "Found no results"` is **0**.
- **10 of 10** Alpine deps extracted and resolved, matching the 10 pins in the `Dockerfile` exactly: `composer`, `nginx`, `php85`, `php85-curl`, `php85-dom`, `php85-fpm`, `php85-iconv`, `php85-mbstring`, `php85-session`, `php85-zip`. No `skipReason`, no warnings.
- No stale pins found, cross-checked against the APKINDEX files directly: every pinned version equals the current APKINDEX version, so Renovate correctly reports no Alpine updates. Nothing in this repository is blocked on a stale pin.
- Every pin exists in either `main` or `community`; none are unresolvable.

The only lookup failures in the dry run log are `github-digest` lookups for `hassio-addons/workflows`, which fail because the container has no GitHub token. They are unrelated to this change.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows the same approach as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved handling of Alpine Linux package versions and updates.
  - Added support for Alpine community packages from the official registry.
  - Enhanced automated update coverage for PHP-related packages.
  - Eligible Alpine package updates can now be applied automatically, helping keep supported environments current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->